### PR TITLE
Add slot to receive `no-shadow` content.

### DIFF
--- a/html-include-element.js
+++ b/html-include-element.js
@@ -95,7 +95,7 @@ export class HTMLIncludeElement extends HTMLElement {
             display: block;
           }
         </style>
-        ${this.noShadow ? '' : text}
+        ${this.noShadow ? '<slot></slot>' : text}
       `;
       this.dispatchEvent(new Event('load'));
     }


### PR DESCRIPTION
Fixes #4 

Because a shadow root is created by default, we must ensure there is always a `slot` element to catch elements applied in the child content when `no-shadow` is `true`.