### PR TITLE
Defer load event until all shadow `link` elements are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Add `<slot>` to project content when using `no-shadow`
 
+### Feature
+* Defer firing the `load` event until all `<link>` elements in the shadow root are finished loading.
+
 ## [0.1.2] - 2019-04-16
 
 ### Fixed

--- a/html-include-element.js
+++ b/html-include-element.js
@@ -1,3 +1,40 @@
+const LINK_LOAD_SUPPORTED = 'onload' in HTMLLinkElement.prototype;
+
+/**
+ * Firefox may throw an error when accessing a not-yet-loaded cssRules property.
+ * @param {HTMLLinkElement}
+ * @return {boolean}
+ */
+function isLinkAlreadyLoaded(link) {
+  try {
+    return !!(link.sheet && link.sheet.cssRules);
+  } catch (error) {
+    if (error.name === 'InvalidAccessError' || 'SecurityError')
+      return false;
+    else
+      throw error;
+  }
+}
+
+/**
+ * Resolves when a `<link>` element has loaded its resource.
+ * Gracefully degrades for browsers that don't support the `load` event on links.
+ * in which case, it immediately resolves, causing a FOUC, but displaying content.
+ * resolves immediately if the stylesheet has already been loaded.
+ * @param  {HTMLLinkElement} link
+ * @return {Promise<StyleSheet>}
+ */
+async function linkLoaded(link) {
+  return new Promise((resolve, reject) => {
+    if (!LINK_LOAD_SUPPORTED) resolve();
+    else if (isLinkAlreadyLoaded(link)) resolve(link.sheet);
+    else {
+      link.addEventListener('load', () => resolve(link.sheet), { once: true });
+      link.addEventListener('error', reject, { once: true });
+    }
+  });
+}
+
 /**
  * Embeds HTML into a document.
  *
@@ -9,7 +46,7 @@
  *
  * By default, the HTML is embedded into a shadow root. If the `no-shadow`
  * attribute is present, the HTML will be embedded into the child content.
- * 
+ *
  */
 export class HTMLIncludeElement extends HTMLElement {
   static get observedAttributes() {
@@ -97,6 +134,13 @@ export class HTMLIncludeElement extends HTMLElement {
         </style>
         ${this.noShadow ? '<slot></slot>' : text}
       `;
+
+      // If we're not using shadow DOM, then the consuming root
+      // is responsible to load its own resources
+      if (!this.noShadow) {
+        await Promise.all([...this.shadowRoot.querySelectorAll('link')].map(linkLoaded));
+      }
+
       this.dispatchEvent(new Event('load'));
     }
   }


### PR DESCRIPTION
fixes #6 