### PR TITLE
rewire short-circuited catch logic

### DIFF
--- a/html-include-element.js
+++ b/html-include-element.js
@@ -9,7 +9,7 @@ function isLinkAlreadyLoaded(link) {
   try {
     return !!(link.sheet && link.sheet.cssRules);
   } catch (error) {
-    if (error.name === 'InvalidAccessError' || 'SecurityError')
+    if (error.name === 'InvalidAccessError' || error.name === 'SecurityError')
       return false;
     else
       throw error;


### PR DESCRIPTION
In isLinkAlreadyLoaded, the predicate used will always be truthy, so the function returns false when errors are thrown even if they aren't either InvalidAccessError or SecurityError types.