### PR TITLE
fix: gracefully recover from link loading errors

### DIFF
--- a/.changeset/link-loading-errors.md
+++ b/.changeset/link-loading-errors.md
@@ -1,0 +1,8 @@
+---
+"html-include-element": patch
+---
+
+When included HTML files are loaded, their subresources (defined with `<link>`
+elements) are loaded as well. If one of those `<link>` elements fails to load,
+`<html-include>` will now gracefully fail, logging the failed url and
+continuing to load the rest of the HTML file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@esm-bundle/chai": "^4.3.4-fix.0",
-        "@web/test-runner": "^0.13.27"
+        "@web/test-runner": "^0.13.27",
+        "hanbi": "^1.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1565,6 +1566,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/hanbi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hanbi/-/hanbi-1.0.1.tgz",
+      "integrity": "sha512-ygE4dxg+khS7BZBZTVqaaq+X3oCQX6q4Z2LvNzRpPdZLmzbmL7xu6KCdjWoRiRlYfyZN9R+gMztf4MftiCH0Mw==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -4675,6 +4682,12 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "hanbi": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hanbi/-/hanbi-1.0.1.tgz",
+      "integrity": "sha512-ygE4dxg+khS7BZBZTVqaaq+X3oCQX6q4Z2LvNzRpPdZLmzbmL7xu6KCdjWoRiRlYfyZN9R+gMztf4MftiCH0Mw==",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
-    "@web/test-runner": "^0.13.27"
+    "@web/test-runner": "^0.13.27",
+    "hanbi": "^1.0.1"
   }
 }

--- a/test/html-include-element_test.js
+++ b/test/html-include-element_test.js
@@ -1,4 +1,5 @@
 import {assert} from '@esm-bundle/chai';
+import {stubMethod, restore} from 'hanbi';
 
 import '../html-include-element.js';
 
@@ -61,6 +62,18 @@ suite('html-include-element', () => {
         res();
       });
     });
+  });
+
+  test('gracefully handles link loading errors', async () => {
+    const stub = stubMethod(console, 'error');
+    container.innerHTML = `
+      <html-include src="./test/test-link-errors.html">TEST</html-include>
+    `;
+    const include = container.querySelector('html-include');
+    await new Promise((res) => include.addEventListener('load', res));
+    assert.isNotNull(include.shadowRoot.querySelector('h1'));
+    assert.isTrue([...stub.calls].some(call => call.args[0]?.match(/^Could not load/)));
+    restore();
   });
 
   // TODO: tests for mode & changing src attribute

--- a/test/test-link-errors.html
+++ b/test/test-link-errors.html
@@ -1,0 +1,4 @@
+<link rel="stylesheet" href="./test/styles.css">
+<link rel="stylesheet" href="./test/error.error">
+<h1>TEST</h1>
+


### PR DESCRIPTION
Depends on #20 

Before: entire partial fails to load if subresource errors:
After: log the failed URL and continue


See tests: without this PR, the shadow content of the partial does not appear on the page